### PR TITLE
Add focus explanation/linking 

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,6 +302,37 @@
             the OS/2 table [[OPEN-FONT-FORMAT]] when performing text layout.
           </p>
         </section>
+        <section id="focus">
+            <h4>Focus</h4>
+            <p>
+              MathML provides the ability for authors to provide
+              interactivity in supporting interactive user agents
+              using the same concepts, approach and guidance to
+              <a data-cite="HTML#focus"><code>Focus</code></a>
+              as described in HTML, with modifications or
+              clarifications regarding application
+              for MathML as described in this section.
+            </p>
+            <p>
+              When an element is focused, all applicable CSS
+              focus-related pseudo-classes as defined in
+              <a data-cite="selectors4#overview">CSS Selectors</a>
+              apply, as defined in that specification.
+            </p>
+            <p>
+              Any MathML elements containing an href attribute are valid links
+              and are focusable.  Their tabindex focus flag
+              must be set unless the user agent normally provides an alternative
+              method of keyboard traversal of links, and they appear in the
+              sequential focus order.
+            </p>
+            <p>
+              The contents of embedded <code>&lt;math&gt;</code> elements
+              (including HTML elements inside token elements),
+              contribute to the sequential focus order of the containing owner HTML
+              document (combined sequential focus order).
+            </p>
+        </section>
       </section>
       <section id="types-for-mathml-attribute-values">
         <h3>Types for MathML Attribute Values</h3>

--- a/index.html
+++ b/index.html
@@ -410,6 +410,18 @@
             This attribute is used to set the directionality of math formulas, which is
             often <code>rtl</code> in Arabic speaking world.
           </p>
+          <section id="event-handler-content-attributes">
+            <h5>Event Handler Content Attributes</h5>
+            <p>
+              All MathML elements support event handler content attributes,
+              as described in  <a data-cite="HTML#event-handler-contentattributes">event handler content attributes</a> in HTML.
+            </p>
+            <p>
+              All event handler content attributes
+              <a data-cite="HTML#event-handlers-on-elements,-document-objects,-and-window-objects">noted by HTML as being supported by all HTMLElements</a>
+              are supported by all MathML elements as well, as defined in the <a href="#dom-and-javascript">MathMLElement IDL</a>.
+            </p>
+          </section>
         </section>
         <section id="legacy-mathml-style-attributes">
           <h4>Legacy MathML Style Attributes</h4>
@@ -487,7 +499,7 @@
             <code>math-</code> prefix.
           </p>
           <div class="note">
-		    <code>mathvariant</code> values other than <code>normal</code>
+		        <code>mathvariant</code> values other than <code>normal</code>
             are implemented for compatibility with full MathML and legacy editors that can't access characters in Plane 1 of Unicode. Authors are encouraged to use the corresponding Unicode characters.
             The <code>normal</code> value is still important to cancel automatic
             italic of the <a><code>&lt;mi&gt;</code></a> element.

--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@
         <section id="focus">
             <h4>Focus</h4>
             <p>
-              MathML provides the ability for authors to provide
+              MathML provides the ability for authors to allow for 
               interactivity in supporting interactive user agents
               using the same concepts, approach and guidance to
               <a data-cite="HTML#focus"><code>Focus</code></a>


### PR DESCRIPTION
Add focus explanation and linking to HTML and CSS specification defining focus related things, related to #131
 