### PR TITLE
update inline spec reporting to use canary/experimental/wpt.fyi

### DIFF
--- a/spec-implementation-report.js
+++ b/spec-implementation-report.js
@@ -5,6 +5,8 @@
   Massage each engines data into a nice indexed
   result set (testPath:result) for quick reference
 */
+
+
 async function getBrowserWPTData(browser) {
     let ret = {
         engine: browser,
@@ -35,9 +37,9 @@ async function getBrowserWPTData(browser) {
 */
 let wptDataPromise = Promise.all([
     getBrowserWPTData('blink'),
-    getBrowserWPTData('blink-no-mathml'),
-    getBrowserWPTData('gecko'),
-    getBrowserWPTData('webkit')
+    getBrowserWPTData('chrome'),
+    getBrowserWPTData('firefox'),
+    getBrowserWPTData('safari')
 ])
 
 /*
@@ -79,10 +81,10 @@ async function initReport() {
 async function loadWebPlaformTestsResults() {
     let wptData = await wptDataPromise;
     let ENGINE_LOGOS = {
-        'gecko': "https://test.csswg.org/harness/img/gecko.svg",
-        'webkit': "https://test.csswg.org/harness/img/webkit.svg",
+        'firefox': "https://test.csswg.org/harness/img/gecko.svg",
+        'safari': "https://test.csswg.org/harness/img/webkit.svg",
         'blink': "https://pbs.twimg.com/profile_images/1576817016/igalia_400x400.png",
-        'blink-no-mathml': "https://test.csswg.org/harness/img/blink.svg",
+        'chrome': "https://test.csswg.org/harness/img/blink.svg",
     };
 
     document.querySelectorAll('.respec-tests-details').forEach(el => {

--- a/wpt/fetch-browser-results.js
+++ b/wpt/fetch-browser-results.js
@@ -1,9 +1,20 @@
 /* -*- Mode: Java; tab-width: 4; indent-tabs-mode:nil; c-basic-offset: 4 -*- */
 /* vim: set ts=4 et sw=4 tw=80: */
+async function fetchWPTFYITestResults(browser) {
+  let response = await fetch(`https://wpt.fyi/api/runs?product=${browser}&label=experimental&label=master`)
+  let result = await response.json()
+  response = await fetch(result[0].raw_results_url)
+  return await response.json()
+}
+
+async function fetchIgaliaBuildWebPlatformTestResults(browser) {
+    let response = await fetch(`https://build-chromium.igalia.com/mathml/wpt/blink-latest.json`);
+    return await response.json();
+}
 
 async function fetchWebPlatformTestResults(browser) {
-    let response = await fetch(`https://build-chromium.igalia.com/mathml/wpt/${browser}-latest.json`);
-    return response.json();
+	let fn = (browser==='blink') ? fetchIgaliaBuildWebPlatformTestResults : fetchWPTFYITestResults;
+	return await fn(browser)
 }
 
 function escapeHTML(source) {


### PR DESCRIPTION
switch non-igalia blink to use wpt-fyi data directly, with experimental platform features enabled