### PR TITLE
Remove redundant include of ElementCSSInlineStyle mixin

### DIFF
--- a/index.html
+++ b/index.html
@@ -820,10 +820,6 @@
             <dfn data-cite="HTML#documentandelementeventhandlers"><code>DocumentAndElementEventHandlers</code></dfn> and
             <dfn data-cite="HTML#htmlorsvgelement"><code>HTMLOrForeignElement</code></dfn> interfaces are defined in
             [[HTML]].</p>
-          <p>The
-            <dfn data-cite="CSSOM#elementcssinlinestyle"><code>ElementCSSInlineStyle</code></dfn>
-            interface is defined in [[CSSOM]].
-          </p>
           <p>Each IDL attribute of the
             <a><code>MathMLElement</code></a> interface
             <a data-cite="HTML#reflect">reflects</a> the

--- a/webidl/MathMLElement.idl
+++ b/webidl/MathMLElement.idl
@@ -3,4 +3,3 @@ interface MathMLElement : Element { };
 MathMLElement includes GlobalEventHandlers;
 MathMLElement includes DocumentAndElementEventHandlers;
 MathMLElement includes HTMLOrForeignElement;
-MathMLElement includes ElementCSSInlineStyle;


### PR DESCRIPTION
CSSOM already does this for the various element interfaces:
https://drafts.csswg.org/cssom/#the-elementcssinlinestyle-mixin